### PR TITLE
Update assertion for tokenization parameters

### DIFF
--- a/lib/src/google_pay.dart
+++ b/lib/src/google_pay.dart
@@ -109,7 +109,7 @@ class GooglePayButton extends StatefulWidget {
     required this.merchantName,
     this.child,
   }) : assert(
-         (tokenizationSpecificationType != TokenizationSpecificationType.paymentGateway),
+         (tokenizationSpecificationType != TokenizationSpecificationType.paymentGateway) && (tokenizationSpecificationParameters != null),
          'Invalid tokenization specification: tokenizationSpecificationParameters are required when type is set to paymentGateway',
        );
 


### PR DESCRIPTION
The assertion now checks that tokenizationSpecificationParameters is not null when tokenizationSpecificationType is set to paymentGateway, ensuring required parameters are provided.