### PR TITLE
Hide pay buttons on unsupported platforms

### DIFF
--- a/lib/flutter_pay_buttons.dart
+++ b/lib/flutter_pay_buttons.dart
@@ -31,6 +31,7 @@ library;
 
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/lib/src/apple_pay.dart
+++ b/lib/src/apple_pay.dart
@@ -151,6 +151,7 @@ class _ApplePayButtonState extends State<ApplePayButton> {
 
   @override
   Widget build(BuildContext context) {
+    if (!Platform.isIOS) return SizedBox.shrink();
     return Padding(
       // Applies external spacing to the button
       padding: widget.margin ?? const EdgeInsets.symmetric(horizontal: 16),

--- a/lib/src/google_pay.dart
+++ b/lib/src/google_pay.dart
@@ -210,6 +210,7 @@ class _GooglePayButtonState extends State<GooglePayButton> {
 
   @override
   Widget build(BuildContext context) {
+    if (!Platform.isAndroid) return SizedBox.shrink();
     return Padding(
       // Applies external spacing to the button
       padding: widget.margin ?? const EdgeInsets.symmetric(horizontal: 16),

--- a/lib/src/google_pay.dart
+++ b/lib/src/google_pay.dart
@@ -109,7 +109,7 @@ class GooglePayButton extends StatefulWidget {
     required this.merchantName,
     this.child,
   }) : assert(
-         (tokenizationSpecificationType != TokenizationSpecificationType.paymentGateway) && (tokenizationSpecificationParameters != null),
+         !(tokenizationSpecificationType == TokenizationSpecificationType.paymentGateway && tokenizationSpecificationParameters == null),
          'Invalid tokenization specification: tokenizationSpecificationParameters are required when type is set to paymentGateway',
        );
 


### PR DESCRIPTION
Added platform checks to ApplePayButton and GooglePayButton widgets to ensure they are only displayed on iOS and Android, respectively. This prevents rendering pay buttons on unsupported platforms.